### PR TITLE
Modifies the delimiter to something more unique

### DIFF
--- a/src/main/resources/_core/compiler/linux/compile-mysql.sh
+++ b/src/main/resources/_core/compiler/linux/compile-mysql.sh
@@ -74,7 +74,7 @@ function make_buildfile_liquibase_compatible(){
 
     if [[ "$line" =~ $end_pattern ]]; then
       echo "END" >> "$cleaned_file"
-      echo "/" >> "$cleaned_file"
+      echo "^" >> "$cleaned_file"
       continue
     fi
 
@@ -84,7 +84,7 @@ function make_buildfile_liquibase_compatible(){
 
     # Add the character '/' on a new line before the statement 'CREATE PROCEDURE...'
     if [[ $line == "CREATE PROCEDURE"* ]]; then
-      echo "/" >> "$cleaned_file"
+      echo "^" >> "$cleaned_file"
     fi
 
     # Write the modified line to the output file

--- a/src/main/resources/_core/compiler/linux/compile-mysql.sh
+++ b/src/main/resources/_core/compiler/linux/compile-mysql.sh
@@ -74,7 +74,7 @@ function make_buildfile_liquibase_compatible(){
 
     if [[ "$line" =~ $end_pattern ]]; then
       echo "END" >> "$cleaned_file"
-      echo "^" >> "$cleaned_file"
+      echo "~" >> "$cleaned_file"
       continue
     fi
 
@@ -84,7 +84,7 @@ function make_buildfile_liquibase_compatible(){
 
     # Add the character '/' on a new line before the statement 'CREATE PROCEDURE...'
     if [[ $line == "CREATE PROCEDURE"* ]]; then
-      echo "^" >> "$cleaned_file"
+      echo "~" >> "$cleaned_file"
     fi
 
     # Write the modified line to the output file


### PR DESCRIPTION
Liquibase keeps failing with double quotes.
So had had to get a single character delimiter that is most likely not used in MYSQL